### PR TITLE
Update lifecycle scripts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,17 @@
 {
     "hostRequirements": {"cpus": 4},
-        
-    "onCreateCommand": "npm install && npm run build",
+
+    "waitFor": "onCreateCommand",
+    "updateContentCommand": "npm install",
     "postCreateCommand": "",
-    
+    "postAttachCommand": {
+      "server": "npm start",
+    },
+
     "customizations": {
       "codespaces": {
         "openFiles": ["src/App.js"]
       }
-    },
-          
-    "postAttachCommand": {
-      "server": "npm start",
     },
 
     "portsAttributes": {


### PR DESCRIPTION
Move dependencies into `updateContentCommand` and wait for `onCreateCommand`

This lets us connect sooner if we don't have a prebuild.