### PR TITLE
Add accessibility-alt-text-bot workflow

### DIFF
--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -1,0 +1,23 @@
+name: accessibility-alt-text-bot
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  accessibility_alt_text_bot:
+    runs-on: ubuntu-latest
+    steps:
+       - uses: github/accessibility-alt-text-bot@v1.4.0


### PR DESCRIPTION
### What

To improve accessibility across GitHub this PR adds the accessibility-alt-text-bot to the codespaces-react template. When others use this template to create a repo, the accessibility-alt-text-bot will already be set up for them.